### PR TITLE
feat(exwm): Interactive resize mode

### DIFF
--- a/modules/k-exwm.el
+++ b/modules/k-exwm.el
@@ -435,6 +435,7 @@ Does not take the minibuffer into account."
 ;; :when isexwm
 ;; :after (exwm)
 ;; :hook (after-init-hook . (lambda () (exwm-wm-mode))))
+<<<<<<< HEAD
 
 (require 'k-exwm-gaps)
 (require 'k-nested-exwm)
@@ -562,6 +563,56 @@ Returns 'horizontal for side-by-side, 'vertical for top-bottom."
           ('horizontal 'vertical)
           ('vertical 'longest)))
   (message "BSP mode: %s" k-exwm-bsp-split-mode))
+
+;;; Resize Mode
+;; Interactive window resizing with Emacs-style keybindings
+
+(defvar k-exwm-resize-amount 50
+  "Pixels to resize by in resize mode.")
+
+(defun k-exwm-resize-left ()
+  "Shrink window from right."
+  (interactive)
+  (shrink-window-horizontally (/ k-exwm-resize-amount (frame-char-width))))
+
+(defun k-exwm-resize-right ()
+  "Grow window to right."
+  (interactive)
+  (enlarge-window-horizontally (/ k-exwm-resize-amount (frame-char-width))))
+
+(defun k-exwm-resize-up ()
+  "Shrink window from bottom."
+  (interactive)
+  (shrink-window (/ k-exwm-resize-amount (frame-char-height))))
+
+(defun k-exwm-resize-down ()
+  "Grow window down."
+  (interactive)
+  (enlarge-window (/ k-exwm-resize-amount (frame-char-height))))
+
+(defvar k-exwm-resize-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "b") #'k-exwm-resize-left)
+    (define-key map (kbd "f") #'k-exwm-resize-right)
+    (define-key map (kbd "p") #'k-exwm-resize-up)
+    (define-key map (kbd "n") #'k-exwm-resize-down)
+    (define-key map (kbd "=") #'balance-windows)
+    (define-key map (kbd "q") #'k-exwm-resize-mode-exit)
+    (define-key map (kbd "RET") #'k-exwm-resize-mode-exit)
+    (define-key map (kbd "C-g") #'k-exwm-resize-mode-exit)
+    map)
+  "Keymap for resize mode.")
+
+(defun k-exwm-resize-mode-exit ()
+  "Exit resize mode."
+  (interactive)
+  (message "Resize mode exited"))
+
+(defun k-exwm-resize-mode ()
+  "Enter resize mode. Use b/n/p/f to resize, q/C-g to exit."
+  (interactive)
+  (message "Resize mode: b/f ←→, p/n ↑↓, = equalize, q to exit")
+  (set-transient-map k-exwm-resize-mode-map t #'k-exwm-resize-mode-exit))
 
 ;;; Initialize EXWM
 (elpaca-wait)


### PR DESCRIPTION
## Summary
Transient mode for interactively resizing windows with Emacs keybindings.

## Features
- Enter resize mode, use simple keys to adjust window sizes
- Uses Emacs-style navigation keys (b/f/p/n)
- Quick balance windows with '='
- Auto-exit when pressing non-resize keys

## Keybindings (in resize mode)
| Key | Action |
|-----|--------|
| `b` | Shrink horizontally (←) |
| `f` | Grow horizontally (→) |
| `p` | Shrink vertically (↑) |
| `n` | Grow vertically (↓) |
| `=` | Balance all windows |
| `q` / `RET` / `C-g` | Exit resize mode |

## Configuration
```elisp
(setq k-exwm-resize-amount 50)  ; pixels per resize step
```

## Suggested Keybinding
```elisp
(global-set-key (kbd "C-c r") #'k-exwm-resize-mode)
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a transient, interactive window resize mode for EXWM buffers.
> 
> - New `k-exwm-resize-mode` with `b/f/p/n` for horizontal/vertical resizing, `=` to `balance-windows`, and `q`/`RET`/`C-g` to exit
> - Configurable step via `k-exwm-resize-amount` (pixels); uses a dedicated `k-exwm-resize-mode-map`
> - Initializes EXWM after adding the resize mode helpers (`elpaca-wait`, `require 'exwm`, `exwm-enable`, `exwm-init`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d2a3427018e45b9317235ff03c1c85f8e9feb67. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->