### PR TITLE
feat(exwm): Nested window manager support via Xephyr

### DIFF
--- a/modules/k-exwm.el
+++ b/modules/k-exwm.el
@@ -437,7 +437,7 @@ Does not take the minibuffer into account."
   :type 'string
   :group 'k-exwm-nested)
 
-(defcustom k-exwm-nested-default-wm "openbox"
+(defcustom k-exwm-nested-default-wm "dwm"
   "Default window manager to run in Xephyr."
   :type 'string
   :group 'k-exwm-nested)


### PR DESCRIPTION
## Summary
Run other window managers inside EXWM using Xephyr nested X server.

This is inspired by ratpoison's "tmpwm" feature - temporarily use another WM for specific tasks without leaving your main environment.

## Features
- Launch any WM in an isolated nested X session
- Run applications inside the nested session
- Manage multiple nested sessions
- Auto-cleanup when Xephyr window closes

## Commands
| Command | Description |
|---------|-------------|
| `k-exwm-nested-start` | Start nested session with a WM |
| `k-exwm-nested-run` | Run command in most recent session |
| `k-exwm-nested-list` | List all active sessions |
| `k-exwm-nested-stop` | Stop specific session |
| `k-exwm-nested-stop-all` | Stop all sessions |

## Configuration
```elisp
(setq k-exwm-nested-default-wm "openbox")  ; or i3, bspwm, etc
(setq k-exwm-nested-size "1280x720")       ; default window size
```

## Requirements
- `Xephyr` (usually in `xserver-xephyr` package)
- The WM you want to run (e.g., openbox, i3, bspwm)

## Use Cases
- Test other WMs without logging out
- Run apps that work better in floating WMs
- Isolate specific workflows
- Demo/testing purposes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces nested WM support via Xephyr to run another window manager inside EXWM.
> 
> - New customization: `k-exwm-nested-size`, `k-exwm-nested-default-wm`; manages sessions in `k-exwm-nested--sessions`
> - Commands: `k-exwm-nested-start`, `k-exwm-nested-run`, `k-exwm-nested-list`, `k-exwm-nested-stop`, `k-exwm-nested-stop-all`
> - Spawns Xephyr and WM processes, sets `DISPLAY`, tracks multiple sessions, and cleans up when Xephyr exits
> - Ensures EXWM is enabled and initialized via `exwm-enable` and `exwm-init`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d1a273dabf3a50058e7961213976025edf2f2bbc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->